### PR TITLE
feat(plot): agregar script para gráfico de reporte

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Todos los resultados de los scripts son almacenados en el directorio `reports/` 
 ### Source
 - **security_checker.py**: Revisa todos los reportes y genera un archivo markdown con las vulnerabilidades encontradas.
 
+### Utils
+
+- **prettify_json.py**: Aplica un formato legible a los archivos JSON generados.
+- **plot_generator.py**: Genera un gráfico de tarta/pie de los archivos JSON generados en el directorio `reports/`.
+
 ## Indicaciones para los desarrolladores
 
 ### Issues

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+contourpy==1.3.2
+cycler==0.12.1
+fonttools==4.58.4
+kiwisolver==1.4.8
+matplotlib==3.10.3
+numpy==2.3.0
+packaging==25.0
+pillow==11.2.1
+pyparsing==3.2.3
+python-dateutil==2.9.0.post0
+six==1.17.0

--- a/util/plot_generator.py
+++ b/util/plot_generator.py
@@ -1,0 +1,66 @@
+import os
+import json
+import matplotlib.pyplot as plt
+
+
+# Extractores específicos
+# Se evita hardcodear a la lógica principal
+def extract_bandit_issues(data):
+    return len(data.get("results", []))
+
+
+def extract_checkov_issues(data):
+    return len(data.get("results", {}).get("failed_checks", []))
+
+
+def extract_shellcheck_issues(data):
+    return len(data.get("comments", []))
+
+
+def extract_tflint_issues(data):
+    return len(data.get("issues", []))
+
+
+TOOLS = {
+    "Bandit": ("bandit.json", extract_bandit_issues),
+    "Checkov": ("checkov.json", extract_checkov_issues),
+    "Shellcheck": ("shellcheck.json", extract_shellcheck_issues),
+    "TFLint": ("tflint_iac.json", extract_tflint_issues),
+}
+
+
+# Funcion para generar reportes
+# Se separan las herramientas del generador del grafico para separar responsabilidades
+def generate_security_report_chart(
+    output_path="reports/summary_chart.svg", report_dir="reports/"
+):
+    issue_counts = {}
+
+    for tool_name, (filename, extractor) in TOOLS.items():
+        file_path = os.path.join(report_dir, filename)
+
+        # Si la herramienta no existe, se omite
+        if not os.path.exists(file_path):
+            continue
+
+        with open(file_path, "r") as file:
+            data = json.load(file)
+
+        # Estraer errores
+        try:
+            issue_counts[tool_name] = extractor(data)
+        except Exception as e:
+            print(f"No se pudo extraer errores de {tool_name}: {e}")
+
+    if not issue_counts:
+        return
+
+    # Hacer gráfico tarta/pie
+    labels = list(issue_counts.keys())
+    sizes = list(issue_counts.values())
+
+    plt.pie(sizes, labels=labels, autopct="%1.1f%%")
+    plt.savefig(output_path, format='svg')
+
+
+generate_security_report_chart()


### PR DESCRIPTION
- Agregar un script Python plot_generator.py en util/ para generar un gráfico de tarta/pie según el número de errores encontrados en los reportes.
- Actualizar documentación para este script y prettify_json.py.
- Incluir requirements.txt por el uso de matplotlib.
- Crear PR para utilizar lógica en creación de dashboard HTML.