### PR TITLE
feat(reports):  mostrar dashboard en servidor HTTP básico

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Todos los resultados de los scripts son almacenados en el directorio `reports/` 
 - **scan_shellcheck.sh**: Ejecuta `shellcheck` para análisis de scripts de shell en `scripts/`.
 - **scan_tflint.sh**: Ejecuta `tflint` sobre los módulos de Terraform en el directorio `iac/`.
 - **run_all_scans.sh**: Ejecuta todos los scripts de escaneo (`scan_bandit.sh`, `scan_checkov.sh`, `scan_shellcheck.sh`, `scan_tflint.sh`) y genera el reporte final con `security_checker.py`.
+- **serve_reports.sh**: Lee el reporte generado por `security_checker.py` y lo sirve en un servidor Python en el navegador.
 
 
 ### Source

--- a/scripts/serve_reports.sh
+++ b/scripts/serve_reports.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Lanza un servidor HTTP local para visualizar los reportes de seguridad y abre el navegador en la vista principal.
+# Los reportes de seguridad son generados por src/security_checker.py
+
+set -e
+
+# Asegurarse de estar en la raíz del proyecto
+cd "$(git rev-parse --show-toplevel)"
+
+REPORT_DIR="reports"
+REPORT_FILE="security_report.html"
+PORT=8000
+URL="http://localhost:${PORT}/${REPORT_FILE}"
+
+# Verificar si el archivo a servir existe
+if [ ! -f "${REPORT_DIR}/${REPORT_FILE}" ]; then
+    echo "! No se encontró ${REPORT_DIR}/${REPORT_FILE}. Asegúrate de haber generado el reporte."
+    exit 1
+fi
+
+echo "Sirviendo directorio ${REPORT_DIR} en http://localhost:${PORT}/"
+echo "Abriendo navegador en ${URL}"
+
+# Abrir navegador si se detecta entorno gráfico
+if command -v xdg-open >/dev/null 2>&1; then
+    # Linux
+    xdg-open "$URL" >/dev/null 2>&1 &
+elif command -v start >/dev/null 2>&1; then
+    # Windows
+    start "$URL"
+else
+    echo "! No se detectó navegador gráfico. Puedes abrir manualmente: $URL"
+fi
+
+# Lanzar servidor HTTP
+cd "$REPORT_DIR"
+if command -v python3 >/dev/null 2>&1; then
+    # Prioridad a python3
+    python3 -m http.server "$PORT"
+elif command -v python >/dev/null 2>&1; then
+    # python en su defecto
+    python -m SimpleHTTPServer "$PORT"
+else
+    echo "! No se encontró ni python3 ni python. Instala Python para servir los reportes."
+    exit 1
+fi


### PR DESCRIPTION
- Agregar script que sirve los reportes generados por security_checker.py en un servidor http.
- Agregar documentación del script en README.md.
- El script toma en cuenta si el usuario está usando Windows o Google y abre el navegador con el dashboard según el sistema operativo.