### PR TITLE
feat(iac): agregar módulo network_dummy y validador de configuración de red

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -37,3 +37,24 @@ resource "null_resource" "dummy_invalid_format" {
     Env   = "DEV"                
   }
 }
+
+# Módulo que simula una configuración de red y genera un archivo JSON con sus valores
+module "network_dummy" {
+  source        = "./network_dummy"
+
+  # Nombre lógico de la red simulada
+  network_name  = "test-network"
+
+  # Rango CIDR asignado a la red
+  cidr_block    = "10.0.0.0/16"
+
+  # Puerto abierto para simular acceso
+  from_port     = 22
+  to_port       = 22
+
+  # Nombre del archivo JSON que se generará
+  file_name     = "network_config.json"
+
+  # Tipo de sistema operativo para determinar el comando correcto
+  os_type = var.os_type
+}

--- a/iac/network_config.json
+++ b/iac/network_config.json
@@ -1,0 +1,10 @@
+﻿{
+    "from_port":  22,
+    "allowed_ips":  [
+                        "0.0.0.0/0"
+                    ],
+    "to_port":  22,
+    "network_name":  "test-network",
+    "cidr_block":  "10.0.0.0/16",
+    "protocol":  "tcp"
+}

--- a/iac/network_dummy/main.tf
+++ b/iac/network_dummy/main.tf
@@ -1,0 +1,33 @@
+# Recurso que genera un archivo de configuración de red JSON en sistemas Windows usando PowerShell
+resource "null_resource" "generate_config_windows" {
+  # Este recurso solo se crea si el valor de os_type es windows
+  count = var.os_type == "windows" ? 1 : 0
+
+  # Fuerza la ejecución del recurso en cada apply
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+
+  provisioner "local-exec" {
+    # Comando PowerShell que genera un archivo json que contiene la configuración de la red
+    command = "ConvertTo-Json @{network_name='${var.network_name}'; cidr_block='${var.cidr_block}'; from_port=${var.from_port}; to_port=${var.to_port}; protocol='${var.protocol}'; allowed_ips=@(${join(", ", formatlist("'%s'", var.allowed_ips))})} | Out-File -Encoding utf8 ${var.file_name}"
+    interpreter = ["PowerShell", "-Command"]
+  }
+}
+
+# Recurso que genera un archivo de configuración de red JSON en sistemas Linux usando Bash
+resource "null_resource" "generate_config_linux" {
+  # Este recurso solo se crea si el valor de os_type es linux
+  count = var.os_type == "linux" ? 1 : 0
+
+  # Fuerza la ejecución del recurso en cada apply
+  triggers = {
+    always_run = "${timestamp()}"
+  }
+
+  provisioner "local-exec" {
+    # Comando Bash que genera un archivo json que contiene la configuración de la red
+    command = "echo '{\"network_name\": \"${var.network_name}\", \"cidr_block\": \"${var.cidr_block}\", \"from_port\": ${var.from_port}, \"to_port\": ${var.to_port}, \"protocol\": \"${var.protocol}\", \"allowed_ips\": ${jsonencode(var.allowed_ips)}}' > ${var.file_name}"
+    interpreter = ["/bin/bash", "-c"]
+  }
+}

--- a/iac/network_dummy/variables.tf
+++ b/iac/network_dummy/variables.tf
@@ -1,0 +1,53 @@
+// CIDR block define el rango de direcciones IP de la red simulada
+variable "cidr_block" {
+  type        = string
+  description = "CIDR block de la red dummy"
+  default     = "10.0.0.0/16"
+}
+
+// Nombre lógico de la red simulada
+variable "network_name" {
+  type        = string
+  description = "Nombre de la red dummy"
+  default     = "dummy-network"
+}
+
+// Puerto de inicio permitido por la regla de red simulada
+variable "from_port" {
+  type        = number
+  description = "Puerto de inicio"
+  default     = 22
+}
+
+// Puerto final permitido 
+variable "to_port" {
+  type        = number
+  description = "Puerto final"
+  default     = 22
+}
+
+// Protocolo de red simulado
+variable "protocol" {
+  type        = string
+  default     = "tcp"
+}
+
+// Lista de IPs permitidas por la regla de red
+variable "allowed_ips" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+
+// Nombre del archivo de salida donde se escribirá el JSON con esta configuración
+variable "file_name" {
+  type        = string
+  description = "Nombre del archivo JSON que se va a generar"
+  default     = "network_config.json"
+}
+
+// Sistema operativo del entorno donde se ejecuta Terraform
+variable "os_type" {
+  type    = string
+  default = "windows" 
+}

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -19,3 +19,10 @@ variable "env" {
     description = "Entorno del recurso"
     default = "dev"
 }
+
+# Sistema operativo del entorno donde se ejecuta Terraform
+variable "os_type" {
+  type        = string
+  description = "Tipo de sistema operativo"
+  default     = "windows"
+}

--- a/scripts/scan_checkov.sh
+++ b/scripts/scan_checkov.sh
@@ -17,3 +17,8 @@ checkov --directory iac/ --external-checks-dir checkov/ --quiet --output json --
 mv reports/results_json.json reports/checkov.json
 
 echo "Escaneo con Checkov completado. Resultados guardados en reports/checkov.json"
+
+# Ejecuta un script para analizar el archivo JSON de configuración de red
+bash scripts/validate_network_json.sh
+
+echo "Validación de configuración de red completada."

--- a/scripts/scan_tflint.sh
+++ b/scripts/scan_tflint.sh
@@ -6,10 +6,13 @@ set -e
 # Asegura que se trabaje desde el directorio raíz del repositorio
 cd "$(git rev-parse --show-toplevel)"
 
+ROOT_DIR=$(pwd)
+
 echo "Iniciando escaneo de TFLint..."
 
 # Crear carpeta reports si no existe
 mkdir -p reports
+
 
 # Ejecutar tflint con salida JSON
 # Se recorre cada módulo
@@ -20,14 +23,14 @@ find iac/ -type d | while read -r dir; do
   module_name=$(basename "$dir")
 
   # Crear un archivo de salida único para cada módulo
-  output_file="reports/tflint_${module_name}.json"
+  output_file="$ROOT_DIR/reports/tflint_${module_name}.json"
 
     (
       cd "$dir"
       # Inicializar terraform (por completitud se deshabilita backend en caso tuviera)
       terraform init -backend=false -input=false -no-color > /dev/null 2>&1
       # Ejecutar tflint y guardar salida
-      tflint --format json --force > "../$output_file"
+      tflint --format json --force > "$output_file"
     )
   fi
 done

--- a/scripts/validate_network_json.sh
+++ b/scripts/validate_network_json.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# Valida el contenido del archivo network_config.json generado por Terraform
+
+set -e
+
+# Ruta del archivo JSON a validar 
+JSON_FILE="iac/network_config.json"
+# Ruta del archivo de reporte
+REPORT_FILE="reports/network_validation_report.json"
+
+mkdir -p reports
+
+# Si el archivo no existe, se registra el error y se detiene
+if [ ! -f "$JSON_FILE" ]; then
+  echo "{\"error\": \"Archivo no encontrado: $JSON_FILE\"}" > "$REPORT_FILE"
+  echo "Archivo no encontrado: $JSON_FILE."
+  exit 0
+fi
+
+# Extraer valores del JSON
+CIDR=$(jq -r '.cidr_block' "$JSON_FILE")
+PORT=$(jq '.from_port' "$JSON_FILE")
+TO_PORT=$(jq '.to_port' "$JSON_FILE")
+NAME=$(jq -r '.network_name' "$JSON_FILE")
+PROTOCOL=$(jq -r '.protocol' "$JSON_FILE")
+ALLOWED_IPS=$(jq -r '.allowed_ips[]' "$JSON_FILE")
+
+# Inicializar listas para errores y advertencias
+ERRORS=()
+WARNINGS=()
+
+HIGH_RISK_PORTS=(21 23 69 109 110 137 138 139 143 445)
+
+# Validación 1: detectar CIDR abierto
+if [[ "$CIDR" == "0.0.0.0/0" ]]; then
+  ERRORS+=("CIDR abierto detectado: $CIDR")
+fi
+
+# Recorrer todos los puertos del rango para aplicar validaciones
+for p in $(seq "$PORT" "$TO_PORT"); do
+  # Validación 2: puertos menores a 1024
+  if [ "$p" -lt 1024 ]; then
+    WARNINGS+=("Puerto inseguro (<1024): $p")
+  fi
+
+  # Validación 3: puertos de alto riesgo
+  for risky in "${HIGH_RISK_PORTS[@]}"; do
+    if [ "$p" -eq "$risky" ]; then
+      ERRORS+=("Puerto de alto riesgo detectado: $p")
+    fi
+  done
+done
+
+# Validación 4: rango de puertos muy amplio
+if [ "$((TO_PORT - PORT))" -gt 100 ]; then
+  WARNINGS+=("Rango de puertos amplio: de $PORT a $TO_PORT")
+fi
+
+# Validación 5: nombre de red por defecto
+if [[ "$NAME" == "dummy-network" ]]; then
+  WARNINGS+=("Nombre de red por defecto usado: $NAME")
+fi
+
+# Validación 6: uso de protocolo permisivo
+if [[ "$PROTOCOL" == "all" ]]; then
+  WARNINGS+=("Protocolo permisivo: $PROTOCOL")
+fi
+
+# Validación 6: IPs peligrosas en la lista de allowed_ips
+for ip in $ALLOWED_IPS; do
+  if [[ "$ip" == "0.0.0.0/0" ]]; then
+    ERRORS+=("IP peligrosa permitida: $ip")
+  fi
+done
+
+# Generar archivo de reporte en JSON
+{
+  echo "{"
+  echo "  \"archivo_analizado\": \"$JSON_FILE\","
+  echo "  \"errores\": ["
+  for ((i = 0; i < ${#ERRORS[@]}; i++)); do
+    echo "    \"${ERRORS[$i]}\"$( [[ $i -lt $((${#ERRORS[@]} - 1)) ]] && echo , )"
+  done
+  echo "  ],"
+  echo "  \"advertencias\": ["
+  for ((i = 0; i < ${#WARNINGS[@]}; i++)); do
+    echo "    \"${WARNINGS[$i]}\"$( [[ $i -lt $((${#WARNINGS[@]} - 1)) ]] && echo , )"
+  done
+  echo "  ]"
+  echo "}"
+} > "$REPORT_FILE"
+
+echo "Resultado en $REPORT_FILE"
+


### PR DESCRIPTION
- Agregar módulo network_dummy para generar un archivo network_config.json con parámetros de red simulada.

- Crear script validate_network_json.sh para analizar configuraciones inseguras en el JSON generado.

- Integrar validación personalizada en scan_checkov.sh para ejecutarse junto al análisis de Checkov.

- Corregir generación de reportes por módulo en scan_tflint.sh usando rutas absolutas.

